### PR TITLE
align ts ffi with db.h abi and bump to 0710

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tidesdb",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tidesdb",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MPL-2.0",
       "dependencies": {
         "koffi": "^2.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidesdb",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "TypeScript bindings for TidesDB - A high-performance embedded key-value storage engine",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/column-family.ts
+++ b/src/column-family.ts
@@ -111,6 +111,13 @@ export class ColumnFamily {
     const tombstoneRatio = (decoded.tombstone_ratio ?? 0) as number;
     const maxSstDensity = (decoded.max_sst_density ?? 0) as number;
     const maxSstDensityLevel = (decoded.max_sst_density_level ?? 0) as number;
+    const walBytesWritten = (decoded.wal_bytes_written ?? 0) as number;
+    const flushBytesWritten = (decoded.flush_bytes_written ?? 0) as number;
+    const compactionBytesWritten = (decoded.compaction_bytes_written ?? 0) as number;
+    const compactionBytesRead = (decoded.compaction_bytes_read ?? 0) as number;
+    const userBytesWritten = (decoded.user_bytes_written ?? 0) as number;
+    const flushCount = (decoded.flush_count ?? 0) as number;
+    const compactionCount = (decoded.compaction_count ?? 0) as number;
 
     // Parse level arrays
     const levelSizes: number[] = [];
@@ -222,6 +229,13 @@ export class ColumnFamily {
       levelTombstoneCounts,
       maxSstDensity,
       maxSstDensityLevel,
+      walBytesWritten,
+      flushBytesWritten,
+      compactionBytesWritten,
+      compactionBytesRead,
+      userBytesWritten,
+      flushCount,
+      compactionCount,
     };
   }
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -60,6 +60,8 @@ export class TidesDBError extends Error {
         return 'database is locked';
       case ErrorCode.ErrReadonly:
         return 'database is read-only';
+      case ErrorCode.ErrBusy:
+        return 'resource is busy';
       default:
         return 'unknown error';
     }

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -74,6 +74,7 @@ export const TidesDBConfigStruct = koffi.struct("tidesdb_config_t", {
   object_store: "void *",
   object_store_config: "void *",
   max_concurrent_flushes: "int",
+  finish_compactions_on_close: "int",
 });
 
 // tidesdb_commit_op_t structure (used by commit hook callback)
@@ -167,6 +168,15 @@ export const DbStatsStruct = koffi.struct("tidesdb_db_stats_t", {
   total_uploads: "uint64_t",
   total_upload_failures: "uint64_t",
   replica_mode: "int",
+  // write-amplification counters (lifetime since open, on-disk framed bytes)
+  uwal_bytes_written: "uint64_t",
+  wal_bytes_written: "uint64_t",
+  flush_bytes_written: "uint64_t",
+  compaction_bytes_written: "uint64_t",
+  compaction_bytes_read: "uint64_t",
+  user_bytes_written: "uint64_t",
+  flush_count: "uint64_t",
+  compaction_count: "uint64_t",
 });
 
 // tidesdb_cache_stats_t structure
@@ -203,6 +213,14 @@ export const StatsStruct = koffi.struct("tidesdb_stats_t", {
   level_tombstone_counts: "uint64_t *",
   max_sst_density: "double",
   max_sst_density_level: "int",
+  // write-amplification counters (lifetime since open, on-disk framed bytes)
+  wal_bytes_written: "uint64_t",
+  flush_bytes_written: "uint64_t",
+  compaction_bytes_written: "uint64_t",
+  compaction_bytes_read: "uint64_t",
+  user_bytes_written: "uint64_t",
+  flush_count: "uint64_t",
+  compaction_count: "uint64_t",
 });
 
 export const StatsStructPtr = koffi.pointer(StatsStruct);
@@ -434,5 +452,26 @@ export const tidesdb_objstore_fs_create = lib.func(
 
 // Memory management
 export const tidesdb_free = lib.func("void tidesdb_free(void *ptr)");
+
+// Initialization / custom allocator support
+export const tidesdb_init = lib.func(
+  "int tidesdb_init(void *malloc_fn, void *calloc_fn, void *realloc_fn, void *free_fn)",
+);
+export const tidesdb_finalize = lib.func("void tidesdb_finalize()");
+
+// Open-file limit
+export const tidesdb_raise_open_file_limit = lib.func(
+  "long tidesdb_raise_open_file_limit(long desired)",
+);
+
+// Cancel background compaction db-wide (fast shutdown)
+export const tidesdb_cancel_background_work = lib.func(
+  "int tidesdb_cancel_background_work(tidesdb_t *db)",
+);
+
+// Query whether a compression backend was compiled into the library
+export const tidesdb_compression_available = lib.func(
+  "int tidesdb_compression_available(int type)",
+);
 
 export { koffi };

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,8 @@ export {
   LogLevel,
   IsolationLevel,
   ErrorCode,
+  BuiltinComparator,
+  ObjStoreBackend,
   Config,
   ColumnFamilyConfig,
   ObjectStoreConfig,

--- a/src/tidesdb.test.ts
+++ b/src/tidesdb.test.ts
@@ -27,6 +27,7 @@ import {
   ErrorCode,
   CommitOp,
   defaultConfig,
+  BuiltinComparator,
 } from "./index";
 
 function createTempDir(): string {
@@ -1534,8 +1535,9 @@ describe("TidesDB", () => {
     test("defaultConfig().maxConcurrentFlushes is sourced from C library", () => {
       const cfg = defaultConfig();
       expect(typeof cfg.maxConcurrentFlushes).toBe("number");
-      // Library default is non-zero (currently TDB_DEFAULT_MAX_CONCURRENT_FLUSHES = 4)
-      expect(cfg.maxConcurrentFlushes).toBeGreaterThan(0);
+      // The library default is 0, which means "pin to the resolved
+      // num_flush_threads" at open time rather than a fixed cap.
+      expect(cfg.maxConcurrentFlushes).toBeGreaterThanOrEqual(0);
     });
   });
 
@@ -1559,6 +1561,228 @@ describe("TidesDB", () => {
       const readTxn = db.beginTransaction();
       expect(readTxn.get(renamedCf, Buffer.from("rk1")).toString()).toBe("rv1");
       readTxn.free();
+    });
+  });
+
+  describe("Library Utilities", () => {
+    test("raiseOpenFileLimit reports a positive ceiling", () => {
+      // desired <= 0 just reports the current ceiling without raising it
+      const current = TidesDB.raiseOpenFileLimit(0);
+      expect(typeof current).toBe("number");
+      expect(current).toBeGreaterThan(0);
+    });
+
+    test("raiseOpenFileLimit toward a target returns an effective ceiling", () => {
+      const current = TidesDB.raiseOpenFileLimit(0);
+      const after = TidesDB.raiseOpenFileLimit(current);
+      // A failed/partial raise is non-fatal; the ceiling never drops below current.
+      expect(after).toBeGreaterThanOrEqual(current);
+    });
+
+    test("isCompressionAvailable returns booleans for every algorithm", () => {
+      for (const algo of [
+        CompressionAlgorithm.NoCompression,
+        CompressionAlgorithm.SnappyCompression,
+        CompressionAlgorithm.Lz4Compression,
+        CompressionAlgorithm.ZstdCompression,
+        CompressionAlgorithm.Lz4FastCompression,
+      ]) {
+        expect(typeof TidesDB.isCompressionAvailable(algo)).toBe("boolean");
+      }
+      // "No compression" is always available.
+      expect(
+        TidesDB.isCompressionAvailable(CompressionAlgorithm.NoCompression),
+      ).toBe(true);
+    });
+
+    test("init is a no-op once the library is already initialized", () => {
+      // beforeEach already opened a db, so the library is initialized.
+      expect(TidesDB.init()).toBe(false);
+    });
+  });
+
+  describe("Cancel Background Work", () => {
+    test("cancelBackgroundWork succeeds and reads still work", () => {
+      db.createColumnFamily("cbw_cf");
+      const cf = db.getColumnFamily("cbw_cf");
+
+      const txn = db.beginTransaction();
+      txn.put(cf, Buffer.from("cbw_key"), Buffer.from("cbw_value"), -1);
+      txn.commit();
+      txn.free();
+
+      expect(() => db.cancelBackgroundWork()).not.toThrow();
+
+      const readTxn = db.beginTransaction();
+      expect(readTxn.get(cf, Buffer.from("cbw_key")).toString()).toBe(
+        "cbw_value",
+      );
+      readTxn.free();
+    });
+
+    test("cancelBackgroundWork throws after close", () => {
+      const dir = createTempDir();
+      try {
+        const tmpDb = TidesDB.open({ dbPath: dir });
+        tmpDb.close();
+        expect(() => tmpDb.cancelBackgroundWork()).toThrow();
+      } finally {
+        removeTempDir(dir);
+      }
+    });
+  });
+
+  describe("finishCompactionsOnClose config", () => {
+    test("defaultConfig exposes finishCompactionsOnClose as a boolean", () => {
+      const cfg = defaultConfig();
+      expect(typeof cfg.finishCompactionsOnClose).toBe("boolean");
+    });
+
+    test("open honors finishCompactionsOnClose without error", () => {
+      const dir = createTempDir();
+      try {
+        const fcDb = TidesDB.open({
+          dbPath: dir,
+          finishCompactionsOnClose: true,
+        });
+        fcDb.createColumnFamily("fc_cf");
+        const cf = fcDb.getColumnFamily("fc_cf");
+        const txn = fcDb.beginTransaction();
+        txn.put(cf, Buffer.from("fck"), Buffer.from("fcv"), -1);
+        txn.commit();
+        txn.free();
+        expect(() => fcDb.close()).not.toThrow();
+      } finally {
+        removeTempDir(dir);
+      }
+    });
+  });
+
+  describe("Write-Amplification Stats", () => {
+    test("column family stats expose write-amplification counters", () => {
+      db.createColumnFamily("wa_cf");
+      const cf = db.getColumnFamily("wa_cf");
+
+      const txn = db.beginTransaction();
+      for (let i = 0; i < 50; i++) {
+        txn.put(cf, Buffer.from(`wa_key_${i}`), Buffer.from(`wa_value_${i}`), -1);
+      }
+      txn.commit();
+      txn.free();
+
+      cf.flushMemtable();
+
+      const stats = cf.getStats();
+      for (const field of [
+        "walBytesWritten",
+        "flushBytesWritten",
+        "compactionBytesWritten",
+        "compactionBytesRead",
+        "userBytesWritten",
+        "flushCount",
+        "compactionCount",
+      ] as const) {
+        expect(typeof stats[field]).toBe("number");
+        expect(stats[field]).toBeGreaterThanOrEqual(0);
+      }
+
+      // We wrote real user bytes, so the denominator must be non-zero.
+      expect(stats.userBytesWritten).toBeGreaterThan(0);
+    });
+
+    test("db stats expose aggregate write-amplification counters", () => {
+      db.createColumnFamily("wa_db_cf");
+      const cf = db.getColumnFamily("wa_db_cf");
+
+      const txn = db.beginTransaction();
+      txn.put(cf, Buffer.from("wadbk"), Buffer.from("wadbv"), -1);
+      txn.commit();
+      txn.free();
+
+      const dbStats = db.getDbStats();
+      for (const field of [
+        "uwalBytesWritten",
+        "walBytesWritten",
+        "flushBytesWritten",
+        "compactionBytesWritten",
+        "compactionBytesRead",
+        "userBytesWritten",
+        "flushCount",
+        "compactionCount",
+      ] as const) {
+        expect(typeof dbStats[field]).toBe("number");
+        expect(dbStats[field]).toBeGreaterThanOrEqual(0);
+      }
+
+      expect(dbStats.userBytesWritten).toBeGreaterThan(0);
+    });
+  });
+
+  describe("ErrBusy Error Code", () => {
+    test("ErrBusy is defined with the correct numeric value", () => {
+      expect(ErrorCode.ErrBusy).toBe(-14);
+    });
+
+    test("ErrBusy maps to a human-readable message", () => {
+      const err = new TidesDBError(ErrorCode.ErrBusy, "op");
+      expect(err.message).toContain("busy");
+      expect(err.code).toBe(ErrorCode.ErrBusy);
+    });
+  });
+
+  describe("Built-in Comparators", () => {
+    test("built-in comparator names are usable without manual registration", () => {
+      // These are auto-registered by the engine on open.
+      const names = [
+        BuiltinComparator.Memcmp,
+        BuiltinComparator.Lexicographic,
+        BuiltinComparator.Uint64,
+        BuiltinComparator.Int64,
+        BuiltinComparator.Reverse,
+        BuiltinComparator.CaseInsensitive,
+      ];
+
+      names.forEach((name, i) => {
+        const cfName = `cmp_cf_${i}`;
+        expect(() =>
+          db.createColumnFamily(cfName, { comparatorName: name }),
+        ).not.toThrow();
+        expect(db.getColumnFamily(cfName).name).toBe(cfName);
+      });
+    });
+
+    test("uint64 comparator orders 8-byte keys numerically", () => {
+      db.createColumnFamily("u64_cf", {
+        comparatorName: BuiltinComparator.Uint64,
+      });
+      const cf = db.getColumnFamily("u64_cf");
+
+      const mk = (n: bigint): Buffer => {
+        const b = Buffer.alloc(8);
+        b.writeBigUInt64LE(n);
+        return b;
+      };
+
+      const txn = db.beginTransaction();
+      // Insert out of order; numeric order should be 2, 10, 256.
+      for (const n of [256n, 2n, 10n]) {
+        txn.put(cf, mk(n), Buffer.from(`v${n}`), -1);
+      }
+      txn.commit();
+      txn.free();
+
+      const readTxn = db.beginTransaction();
+      const iter = readTxn.newIterator(cf);
+      const order: bigint[] = [];
+      iter.seekToFirst();
+      while (iter.isValid()) {
+        order.push(iter.key().readBigUInt64LE());
+        iter.next();
+      }
+      iter.free();
+      readTxn.free();
+
+      expect(order).toEqual([2n, 10n, 256n]);
     });
   });
 });

--- a/src/tidesdb.ts
+++ b/src/tidesdb.ts
@@ -38,8 +38,13 @@ import {
   tidesdb_get_db_stats,
   tidesdb_delete_column_family,
   tidesdb_promote_to_primary,
+  tidesdb_cancel_background_work,
   tidesdb_objstore_default_config,
   tidesdb_objstore_fs_create,
+  tidesdb_init,
+  tidesdb_finalize,
+  tidesdb_raise_open_file_limit,
+  tidesdb_compression_available,
 } from "./ffi";
 import { checkResult, TidesDBError } from "./error";
 import { ColumnFamily } from "./column-family";
@@ -82,6 +87,7 @@ export function defaultConfig(): Partial<Config> {
     unifiedMemtableSyncMode: cConfig.unified_memtable_sync_mode as SyncMode,
     unifiedMemtableSyncIntervalUs: cConfig.unified_memtable_sync_interval_us as number,
     maxConcurrentFlushes: cConfig.max_concurrent_flushes as number,
+    finishCompactionsOnClose: (cConfig.finish_compactions_on_close as number) !== 0,
   };
 }
 
@@ -154,6 +160,58 @@ export class TidesDB {
   }
 
   /**
+   * Explicitly initialize the TidesDB library, optionally with custom memory
+   * allocators. This is **optional** -- the library auto-initializes on first
+   * use with the system allocator. Custom allocators are not supported from
+   * TypeScript, so this always uses the system allocator.
+   *
+   * MUST be called before any other TidesDB call if used. Calling it after the
+   * library has already initialized (e.g. after the first `open()`) is a no-op.
+   *
+   * @returns `true` if this call performed the initialization, `false` if the
+   *          library was already initialized.
+   */
+  static init(): boolean {
+    return tidesdb_init(null, null, null, null) === 0;
+  }
+
+  /**
+   * Finalize the TidesDB library and reset the allocator. After this call,
+   * `init()` may be called again.
+   *
+   * Advanced / teardown use only. Do not call while any database, transaction,
+   * iterator, or registered callback is still live -- doing so invalidates them.
+   */
+  static finalize(): void {
+    tidesdb_finalize();
+  }
+
+  /**
+   * Raise this process's open-file ceiling toward `desired` descriptors so a
+   * database can keep more SSTables open. Call **before** `open()` -- the engine
+   * sizes `maxOpenSSTables` to fit the ceiling at open time. An explicit,
+   * opt-in operator action; a failed or partial raise is non-fatal.
+   *
+   * @param desired Target descriptor count; `<= 0` just reports the current ceiling.
+   * @returns The open-file ceiling in effect after the attempt.
+   */
+  static raiseOpenFileLimit(desired: number): number {
+    return tidesdb_raise_open_file_limit(desired) as number;
+  }
+
+  /**
+   * Query whether a compression backend was compiled into the linked library.
+   * Every algorithm is always defined, but whether it can actually be used is a
+   * build-time choice (the `-DTIDESDB_WITH_*` options).
+   *
+   * @param algorithm Compression algorithm to check.
+   * @returns `true` if the backend is available at runtime.
+   */
+  static isCompressionAvailable(algorithm: CompressionAlgorithm): boolean {
+    return tidesdb_compression_available(algorithm) !== 0;
+  }
+
+  /**
    * Open a TidesDB database with the given configuration.
    */
   static open(config: Config): TidesDB {
@@ -212,6 +270,7 @@ export class TidesDB {
       object_store: objStorePtr,
       object_store_config: objStoreCfg,
       max_concurrent_flushes: mergedConfig.maxConcurrentFlushes ?? 0,
+      finish_compactions_on_close: mergedConfig.finishCompactionsOnClose ? 1 : 0,
     };
 
     const dbPtrOut: unknown[] = [null];
@@ -514,6 +573,21 @@ export class TidesDB {
   }
 
   /**
+   * Cancel background compaction db-wide. In-flight merges bail safely and
+   * queued compaction is skipped; flushes are unaffected so durability is
+   * preserved. Blocks (bounded) until compaction is idle.
+   *
+   * Sticky for the session and reset on next open -- intended to be called
+   * right before `close()` for a fast shutdown.
+   */
+  cancelBackgroundWork(): void {
+    if (!this._db) throw new Error("Database has been closed");
+
+    const result = tidesdb_cancel_background_work(this._db);
+    checkResult(result, "failed to cancel background work");
+  }
+
+  /**
    * Get aggregate statistics across the entire database instance.
    * The returned struct is stack-allocated; no free is needed.
    */
@@ -552,6 +626,14 @@ export class TidesDB {
       total_uploads: 0,
       total_upload_failures: 0,
       replica_mode: 0,
+      uwal_bytes_written: 0,
+      wal_bytes_written: 0,
+      flush_bytes_written: 0,
+      compaction_bytes_written: 0,
+      compaction_bytes_read: 0,
+      user_bytes_written: 0,
+      flush_count: 0,
+      compaction_count: 0,
     };
 
     const result = tidesdb_get_db_stats(this._db, cStats);
@@ -599,6 +681,14 @@ export class TidesDB {
       totalUploads: cStats.total_uploads as number,
       totalUploadFailures: cStats.total_upload_failures as number,
       replicaMode: cStats.replica_mode !== 0,
+      uwalBytesWritten: cStats.uwal_bytes_written as number,
+      walBytesWritten: cStats.wal_bytes_written as number,
+      flushBytesWritten: cStats.flush_bytes_written as number,
+      compactionBytesWritten: cStats.compaction_bytes_written as number,
+      compactionBytesRead: cStats.compaction_bytes_read as number,
+      userBytesWritten: cStats.user_bytes_written as number,
+      flushCount: cStats.flush_count as number,
+      compactionCount: cStats.compaction_count as number,
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,36 @@ export enum ErrorCode {
   ErrUnknown = -11,
   ErrLocked = -12,
   ErrReadonly = -13,
+  ErrBusy = -14,
+}
+
+/**
+ * Names of the built-in comparators that TidesDB auto-registers on database
+ * open. Use any of these as `ColumnFamilyConfig.comparatorName` without calling
+ * `registerComparator()` first.
+ */
+export enum BuiltinComparator {
+  /** Binary byte-by-byte comparison (default). Shorter key sorts first on tie. */
+  Memcmp = "memcmp",
+  /** Null-terminated string comparison via `strcmp()`. Keys must be null-terminated. */
+  Lexicographic = "lexicographic",
+  /** Unsigned 64-bit integer comparison; falls back to memcmp if key size != 8. */
+  Uint64 = "uint64",
+  /** Signed 64-bit integer comparison; falls back to memcmp if key size != 8. */
+  Int64 = "int64",
+  /** Reverse binary comparison (descending order). */
+  Reverse = "reverse",
+  /** Case-insensitive ASCII comparison (A-Z folded to a-z). */
+  CaseInsensitive = "case_insensitive",
+}
+
+/**
+ * Object store backend identifiers reported by the engine.
+ */
+export enum ObjStoreBackend {
+  Fs = 0,
+  S3 = 1,
+  Unknown = 99,
 }
 
 /**
@@ -140,6 +170,12 @@ export interface Config {
    * many column families flush at once. 0 falls back to the library default.
    */
   maxConcurrentFlushes?: number;
+  /**
+   * Close behavior. `false` (default) cancels in-flight compactions at their
+   * next checkpoint for a fast shutdown (no data loss). `true` lets in-flight
+   * compactions run to completion before `close()` returns.
+   */
+  finishCompactionsOnClose?: boolean;
   /** Write logs to file instead of stderr. Default: false */
   logToFile?: boolean;
   /** Log file truncation size in bytes. Default: 24MB, 0 = no truncation */
@@ -271,6 +307,28 @@ export interface Stats {
   maxSstDensity: number;
   /** 1-based level index where `maxSstDensity` was observed (0 if no SSTables). */
   maxSstDensityLevel: number;
+  /**
+   * Framed bytes appended to this CF's WAL (lifetime since open). Always `0` in
+   * unified-memtable mode -- the shared WAL volume is reported db-wide via
+   * `DbStats.uwalBytesWritten`.
+   */
+  walBytesWritten: number;
+  /** On-disk bytes this CF's flushes wrote to L0 SSTables (lifetime since open). */
+  flushBytesWritten: number;
+  /** On-disk bytes this CF's compactions wrote (lifetime since open). */
+  compactionBytesWritten: number;
+  /** On-disk bytes this CF's compactions read as input (lifetime since open). */
+  compactionBytesRead: number;
+  /**
+   * Logical key+value bytes committed to this CF (write-amplification
+   * denominator). CF write amplification = (wal + flush + compaction writes) /
+   * `userBytesWritten`.
+   */
+  userBytesWritten: number;
+  /** Flushed SSTables produced by this CF (lifetime since open). */
+  flushCount: number;
+  /** Compaction output SSTables produced by this CF (lifetime since open). */
+  compactionCount: number;
 }
 
 /**
@@ -339,6 +397,28 @@ export interface DbStats {
   totalUploadFailures: number;
   /** Whether running in read-only replica mode. */
   replicaMode: boolean;
+  /**
+   * Framed bytes appended to the shared unified WAL (lifetime since open).
+   * `0` when unified-memtable mode is off.
+   */
+  uwalBytesWritten: number;
+  /** Per-CF WAL bytes summed across all column families (lifetime since open). */
+  walBytesWritten: number;
+  /** Flush output bytes summed across all column families (lifetime since open). */
+  flushBytesWritten: number;
+  /** Compaction output bytes summed across all column families (lifetime since open). */
+  compactionBytesWritten: number;
+  /** Compaction input bytes summed across all column families (lifetime since open). */
+  compactionBytesRead: number;
+  /**
+   * Logical committed bytes summed across all column families. Db-wide write
+   * amplification = (uwal + wal + flush + compaction writes) / `userBytesWritten`.
+   */
+  userBytesWritten: number;
+  /** Flushed SSTables summed across all column families (lifetime since open). */
+  flushCount: number;
+  /** Compaction output SSTables summed across all column families (lifetime since open). */
+  compactionCount: number;
 }
 
 /**


### PR DESCRIPTION
audited db.h against the typescript bindings and the linked libtidesdb so nine three six and fixed what was missing or wrong

fixed struct truncation that caused out of bounds memory access added finish compactions on close to the config struct so open and default config no longer read past the buffer
added the eight write amplification fields to db stats which the caller allocates so get db stats no longer overflows the heap by sixty four bytes added the seven write amplification fields to the cf stats struct

bound functions that existed in the library but were never exposed tidesdb init and tidesdb finalize as static init and finalize tidesdb raise open file limit as static raise open file limit tidesdb compression available as static is compression available tidesdb cancel background work as cancel background work

added err busy minus fourteen with a message
added the builtin comparator enum for the six auto registered comparators added the obj store backend enum

skipped the s3 connector since the linked build has no s3 symbols and binding them would break module import

added fourteen tests covering all of the above and fixed one stale assertion since the library default for max concurrent flushes changed from four to zero meaning pin to num flush threads

eighty six tests pass